### PR TITLE
(fix):invalid configuration object

### DIFF
--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -178,7 +178,6 @@ module.exports = {
   devServer: {
     contentBase: './client',
     historyApiFallback: true,
-    inject: true,
     port: 3000,
     compress: isProd,
     stats: {


### PR DESCRIPTION
fix for [issue 5](https://github.com/GoogleChrome/preload-webpack-plugin/issues/5)