### PR TITLE
Make it compatible with node 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class PreloadPlugin {
             asyncChunksSource = compilation.chunks
               .map(chunk => chunk.files);
           }
-          extractedChunks = [].concat(...asyncChunksSource);
+          extractedChunks = [].concat(asyncChunksSource);
         } else if (options.include === 'all') {
             // Async chunks, vendor chunks, normal chunks.
           extractedChunks = compilation

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class PreloadPlugin {
             asyncChunksSource = compilation.chunks
               .map(chunk => chunk.files);
           }
-          extractedChunks = [].concat(asyncChunksSource);
+          extractedChunks = [].concat.apply([], asyncChunksSource);
         } else if (options.include === 'all') {
             // Async chunks, vendor chunks, normal chunks.
           extractedChunks = compilation


### PR DESCRIPTION
Hi there ✋ 

This plugin is not compatible with node 4 because of the `...asyncChunksSource` syntax which throws an error.

I am using this plugin for [nuxt.js](https://github.com/nuxt/nuxt.js) and I have to choose between dropping node 4 support or removing this plugin (see [failed tests](https://travis-ci.org/nuxt/nuxt.js/jobs/204303766)). This PR will fix this dilemma 😄 

Thank you