### PR TITLE
fix `include` feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ class PreloadPlugin {
                 }
                 return options.include.indexOf(chunkName) > -1;
               })
-              .map(chunk => chunk.files);
+              .map(chunk => chunk.files)
+              .reduce((prev, curr) => prev.concat(curr), []);
         }
 
         const publicPath = compilation.outputOptions.publicPath || '';

--- a/test/spec.js
+++ b/test/spec.js
@@ -189,6 +189,37 @@ describe('PreloadPlugin filters chunks', function() {
     });
     compiler.outputFileSystem = new MemoryFileSystem();
   });
+  it('based on chunkname with sourcemap', function(done) {
+    const compiler = webpack({
+      entry: path.join(__dirname, 'fixtures', 'file.js'),
+      devtool: 'cheap-source-map',
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'bundle.js',
+        chunkFilename: '[name].js',
+        publicPath: '/',
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin({
+          rel: 'preload',
+          as: 'script',
+          include: ['home'],
+          // disable default file blacklist, to include map file
+          fileBlacklist: [],
+        })
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="preload" href="/home.js');
+      expect(html).toContain('<link rel="preload" href="/home.js.map');
+      expect(html).not.toContain('<link rel="preload" href="/bundle.js"');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
 });
 
 describe('filtering unwanted files', function() {


### PR DESCRIPTION
`include` feature will not work properly when sourcemap is generated
(i.e. chunk.files is an array). fix this issue by flattening output
array.