### PR TITLE
Support CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,34 +9,34 @@ preload-webpack-plugin
 A Webpack plugin for automatically wiring up asynchronous (and other types) of JavaScript
 chunks using `<link rel='preload'>`. This helps with lazy-loading.
 
-Note: This is an extension plugin for [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) - a plugin that 
+Note: This is an extension plugin for [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) - a plugin that
 simplifies the creation of HTML files to serve your webpack bundles.
 
-This plugin is a stop-gap until we add support for asynchronous chunk wiring to 
+This plugin is a stop-gap until we add support for asynchronous chunk wiring to
 [script-ext-html-webpack-plugin](https://github.com/numical/script-ext-html-webpack-plugin/pull/9).
 
 Introduction
 ------------
 
-[Preload](https://w3c.github.io/preload/) is a web standard aimed at improving performance 
+[Preload](https://w3c.github.io/preload/) is a web standard aimed at improving performance
 and granular loading of resources. It is a declarative fetch that can tell a browser to start fetching a
 source because a developer knows the resource will be needed soon. [Preload: What is it good for?](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/)
 is a recommended read if you haven't used the feature before.
 
 In simple web apps, it's straight-forward to specify static paths to scripts you
-would like to preload - especially if their names or locations are unlikely to change. In more complex apps, 
-JavaScript can be split into "chunks" (that represent routes or components) at with dynamic 
+would like to preload - especially if their names or locations are unlikely to change. In more complex apps,
+JavaScript can be split into "chunks" (that represent routes or components) at with dynamic
 names. These names can include hashes, numbers and other properties that can change with each build.
 
 For example, `chunk.31132ae6680e598f8879.js`.
 
-To make it easier to wire up async chunks for lazy-loading, this plugin offers a drop-in way to wire them up 
+To make it easier to wire up async chunks for lazy-loading, this plugin offers a drop-in way to wire them up
 using `<link rel='preload'>`.
 
 Pre-requisites
 --------------
-This module requires Webpack 2.2.0 and above. It also requires that you're using 
-[html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) in your Webpack project. 
+This module requires Webpack 2.2.0 and above. It also requires that you're using
+[html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) in your Webpack project.
 
 Installation
 ---------------
@@ -68,30 +68,45 @@ and finally, configure the plugin in your Webpack `plugins` array after `HtmlWeb
 plugins: [
   new HtmlWebpackPlugin(),
   new PreloadWebpackPlugin()
-]  
+]
 ```
 
-By default, the plugin will assume async script chunks will be preloaded with `as=script`.
-This is the equivalent of:
+When preloading files, the plugin will use different `as` attribute depends on the type of each
+file. For each file ends with `.css`, the plugin will preload it with `as=style`, while for all
+other files, `as=script` will be used.
+
+If you do not prefer to determine `as` attribute depends on suffix of filename, you can also
+explicitly name it using `as`:
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin(),
+  new PreloadWebpackPlugin({
+    rel: 'preload',
+    as: 'script'
+  })
+]
+```
+
+By default, the plugin will assume async script chunks will be preloaded. This is the equivalent of:
 
 ```js
 plugins: [
   new HtmlWebpackPlugin(),
   new PreloadWebpackPlugin({
     rel: 'preload',
-    as: 'script',
     include: 'asyncChunks'
   })
 ]
 ```
 
-For a project generating two async scripts with dynamically generated names, such as 
+For a project generating two async scripts with dynamically generated names, such as
 `chunk.31132ae6680e598f8879.js` and `chunk.d15e7fdfc91b34bb78c4.js`, the following preloads
 will be injected into the document `<head>`:
 
 ```html
-<link rel="preload" href="chunk.31132ae6680e598f8879.js" as="script">
-<link rel="preload" href="chunk.d15e7fdfc91b34bb78c4.js" as="script">
+<link rel="preload" as="script" href="chunk.31132ae6680e598f8879.js">
+<link rel="preload" as="script" href="chunk.d15e7fdfc91b34bb78c4.js">
 ```
 
 You can also configure the plugin to preload all chunks (vendor, async, normal chunks) using
@@ -102,7 +117,6 @@ plugins: [
   new HtmlWebpackPlugin(),
   new PreloadWebpackPlugin({
     rel: 'preload',
-    as: 'script',
     include: 'all'
   })
 ]
@@ -114,7 +128,6 @@ plugins: [
   new HtmlWebpackPlugin(),
   new PreloadWebpackPlugin({
     rel: 'preload',
-    as: 'script',
     include: ['home']
   })
 ]
@@ -123,7 +136,7 @@ plugins: [
 will inject just this:
 
 ```html
-<link rel="preload" href="home.31132ae6680e598f8879.js" as="script">
+<link rel="preload" as="script" href="home.31132ae6680e598f8879.js">
 ```
 
 Filtering chunks
@@ -186,7 +199,7 @@ submitting a pull request through GitHub.
 Contributing workflow
 ---------------------
 
-`index.js` contains the primary source for the plugin, `test` contains tests and `demo` contains demo code. 
+`index.js` contains the primary source for the plugin, `test` contains tests and `demo` contains demo code.
 
 Test the plugin:
 
@@ -203,16 +216,16 @@ $ npm run lint-fix # fix linting issues
 ```
 
 The project is written in ES2015, but does not use a build-step. This may change depending on
-any Node version support requests posted to the issue tracker. 
+any Node version support requests posted to the issue tracker.
 
 Additional Notes
 ---------------------------
 
-* Be careful not to `preload` resources a user is unlikely to need. This can waste their bandwidth. 
+* Be careful not to `preload` resources a user is unlikely to need. This can waste their bandwidth.
 * Use `preload` for the current session if you think a user is likely to visit the next page. There is no
-100% guarantee preloaded items will end up in the HTTP Cache and read locally beyond this session.
+  100% guarantee preloaded items will end up in the HTTP Cache and read locally beyond this session.
 * If optimising for future sessions, use `prefetch` and `preconnect`. Prefetched resources are maintained
-in the HTTP Cache for at least 5 minutes (in Chrome) regardless of the resource's cachability.
+  in the HTTP Cache for at least 5 minutes (in Chrome) regardless of the resource's cachability.
 
 Related plugins
 --------------------------

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ plugins: [
 ]
 ```
 
-In case you need more fine control of the `as` atribute, you could also provide a function here.
+In case you need more fine-grained control of the `as` atribute, you could also provide a function here.
 When using it, entry name will be provided as the parameter, and function itself should return a
 string for `as` attribute:
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ plugins: [
 
 When preloading files, the plugin will use different `as` attribute depends on the type of each
 file. For each file ends with `.css`, the plugin will preload it with `as=style`, for each file ends
-with `.woff`, `.woff2`, `.eot`, `.otf` or `.ttf`, the plugin will preload it with `as=font`, while
-for all other files, `as=script` will be used.
+with `.woff2`, the plugin will preload it with `as=font`, while for all other files, `as=script`
+will be used.
 
 If you do not prefer to determine `as` attribute depends on suffix of filename, you can also
 explicitly name it using `as`:
@@ -100,6 +100,7 @@ plugins: [
     rel: 'preload',
     as(entry) {
       if (/\.css$/.test(entry)) return 'style';
+      if (/\.woff$/.test(entry)) return 'font';
       if (/\.png$/.test(entry)) return 'image';
       return 'script';
     }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ plugins: [
 ]
 ```
 
+In case you need more fine control of the `as` atribute, you could also provide a function here.
+When using it, entry name will be provided as the parameter, and function itself should return a
+string for `as` attribute:
+
+```javascript
+plugins: [
+  new HtmlWebpackPlugin(),
+  new PreloadWebpackPlugin({
+    rel: 'preload',
+    as(entry) {
+      if (/\.css$/.test(entry)) return 'style';
+      if (/\.png$/.test(entry)) return 'image';
+      return 'script';
+    }
+  })
+]
+```
+
 By default, the plugin will assume async script chunks will be preloaded. This is the equivalent of:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ plugins: [
 ```
 
 When preloading files, the plugin will use different `as` attribute depends on the type of each
-file. For each file ends with `.css`, the plugin will preload it with `as=style`, while for all
-other files, `as=script` will be used.
+file. For each file ends with `.css`, the plugin will preload it with `as=style`, for each file ends
+with `.woff`, `.woff2`, `.eot`, `.otf` or `.ttf`, the plugin will preload it with `as=font`, while
+for all other files, `as=script` will be used.
 
 If you do not prefer to determine `as` attribute depends on suffix of filename, you can also
 explicitly name it using `as`:
@@ -105,6 +106,9 @@ plugins: [
   })
 ]
 ```
+
+Notice that if `as=font` is used in preload, crossorigin will be added, otherwise the font resource
+might be double fetched. Explains can be found in [this article](https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf).
 
 By default, the plugin will assume async script chunks will be preloaded. This is the equivalent of:
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class PreloadPlugin {
             let asValue;
             if (!options.as) {
               if (entry.match(/\.css$/)) asValue = 'style';
-              else if (entry.match(/\.(?:eot|otf|ttf|woff2?)$/)) asValue = 'font';
+              else if (entry.match(/\.woff2$/)) asValue = 'font';
               else asValue = 'script';
             } else if (typeof options.as === 'function') {
               asValue = options.as(entry);

--- a/index.js
+++ b/index.js
@@ -75,13 +75,16 @@ class PreloadPlugin {
             // value depends on suffix of filename. Otherwise use the given `as` value.
             let asValue;
             if (!options.as) {
-              asValue = entry.match(/\.css$/) ? 'style' : 'script';
+              if (entry.match(/\.css$/)) asValue = 'style';
+              else if (entry.match(/\.(?:eot|otf|ttf|woff2?)$/)) asValue = 'font';
+              else asValue = 'script';
             } else if (typeof options.as === 'function') {
               asValue = options.as(entry);
             } else {
               asValue = options.as;
             }
-            filesToInclude+= `<link rel="${options.rel}" as="${asValue}" href="${entry}">\n`;
+            const crossOrigin = asValue === 'font' ? 'crossorigin="crossorigin" ' : '';
+            filesToInclude+= `<link rel="${options.rel}" as="${asValue}" ${crossOrigin}href="${entry}">\n`;
           } else {
             // If preload isn't specified, the only other valid entry is prefetch here
             // You could specify preconnect but as we're dealing with direct paths to resources

--- a/index.js
+++ b/index.js
@@ -76,6 +76,8 @@ class PreloadPlugin {
             let asValue;
             if (!options.as) {
               asValue = entry.match(/\.css$/) ? 'style' : 'script';
+            } else if (typeof options.as === 'function') {
+              asValue = options.as(entry);
             } else {
               asValue = options.as;
             }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@
 const objectAssign = require('object-assign');
 const defaultOptions = {
   rel: 'preload',
-  as: 'script',
   include: 'asyncChunks',
   fileBlacklist: [/\.map/]
 };
@@ -78,7 +77,15 @@ class PreloadPlugin {
         }).forEach(entry => {
           entry = `${publicPath}${entry}`;
           if (options.rel === 'preload') {
-            filesToInclude+= `<link rel="${options.rel}" href="${entry}" as="${options.as}">\n`;
+            // If `as` value is not provided in option, dynamically determine the correct
+            // value depends on suffix of filename. Otherwise use the given `as` value.
+            let asValue;
+            if (!options.as) {
+              asValue = entry.match(/\.css$/) ? 'style' : 'script';
+            } else {
+              asValue = options.as;
+            }
+            filesToInclude+= `<link rel="${options.rel}" as="${asValue}" href="${entry}">\n`;
           } else {
             // If preload isn't specified, the only other valid entry is prefetch here
             // You could specify preconnect but as we're dealing with direct paths to resources

--- a/test/spec.js
+++ b/test/spec.js
@@ -191,6 +191,35 @@ describe('PreloadPlugin preloads normal chunks', function() {
     compiler.outputFileSystem = new MemoryFileSystem();
   });
 
+  it('adds preload using "font" for fonts and add crossorigin attribute', (done) => {
+    const compiler = webpack({
+      entry: {
+        js: path.join(__dirname, 'fixtures', 'file.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'bundle.js',
+        chunkFilename: 'chunk.[chunkhash].woff2',
+        publicPath: '/',
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin({
+          rel: 'preload',
+          include: 'all'
+        })
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="preload" as="font" crossorigin="crossorigin" href="/chunk');
+      expect(html).toContain('<link rel="preload" as="script" href="/bundle.js"');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+
   it('use custom as attribute based on return value of callback', (done) => {
     const compiler = webpack({
       entry: path.join(__dirname, 'fixtures', 'file.js'),

--- a/test/spec.js
+++ b/test/spec.js
@@ -44,8 +44,8 @@ describe('PreloadPlugin preloads or prefetches async chunks', function() {
       expect(err).toBeFalsy();
       expect(JSON.stringify(result.compilation.errors)).toBe('[]');
       const html = result.compilation.assets['index.html'].source();
-      expect(html).toContain('<link rel="preload" href="/chunk.');
-      expect(html).not.toContain('<link rel="preload" href="/bundle.');
+      expect(html).toContain('<link rel="preload" as="script" href="/chunk.');
+      expect(html).not.toContain('<link rel="preload" as="script" href="/bundle.');
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();
@@ -97,8 +97,8 @@ describe('PreloadPlugin preloads or prefetches async chunks', function() {
       expect(err).toBeFalsy();
       expect(JSON.stringify(result.compilation.errors)).toBe('[]');
       const html = result.compilation.assets['index.html'].source();
-      expect(html).toContain('<link rel="preload" href="http://mycdn.com/chunk.');
-      expect(html).not.toContain('<link rel="preload" href="http://mycdn.com/bundle.');
+      expect(html).toContain('<link rel="preload" as="script" href="http://mycdn.com/chunk.');
+      expect(html).not.toContain('<link rel="preload" as="script" href="http://mycdn.com/bundle.');
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();
@@ -127,8 +127,65 @@ describe('PreloadPlugin preloads normal chunks', function() {
       expect(err).toBeFalsy();
       expect(JSON.stringify(result.compilation.errors)).toBe('[]');
       const html = result.compilation.assets['index.html'].source();
-      expect(html).toContain('<link rel="preload" href="/chunk');
-      expect(html).toContain('<link rel="preload" href="/bundle.js"');
+      expect(html).toContain('<link rel="preload" as="script" href="/chunk');
+      expect(html).toContain('<link rel="preload" as="script" href="/bundle.js"');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+
+  it('adds preload using "style" for css and "script" for others', (done) => {
+    const compiler = webpack({
+      entry: {
+        js: path.join(__dirname, 'fixtures', 'file.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'bundle.js',
+        chunkFilename: 'chunk.[chunkhash].css',
+        publicPath: '/',
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin({
+          rel: 'preload',
+          include: 'all'
+        })
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="preload" as="style" href="/chunk');
+      expect(html).toContain('<link rel="preload" as="script" href="/bundle.js"');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+
+  it('force value of "as" attribute when provided in option', (done) => {
+    const compiler = webpack({
+      entry: path.join(__dirname, 'fixtures', 'file.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'bundle.js',
+        chunkFilename: 'chunk.[chunkhash].css',
+        publicPath: '/',
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin({
+          rel: 'preload',
+          as: 'script',
+          include: 'all'
+        })
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="preload" as="script" href="/chunk');
+      expect(html).toContain('<link rel="preload" as="script" href="/bundle.js"');
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();
@@ -183,8 +240,8 @@ describe('PreloadPlugin filters chunks', function() {
       expect(err).toBeFalsy();
       expect(JSON.stringify(result.compilation.errors)).toBe('[]');
       const html = result.compilation.assets['index.html'].source();
-      expect(html).toContain('<link rel="preload" href="/home');
-      expect(html).not.toContain('<link rel="preload" href="/bundle.js"');
+      expect(html).toContain('<link rel="preload" as="script" href="/home');
+      expect(html).not.toContain('<link rel="preload" as="script" href="/bundle.js"');
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();
@@ -213,9 +270,9 @@ describe('PreloadPlugin filters chunks', function() {
       expect(err).toBeFalsy();
       expect(JSON.stringify(result.compilation.errors)).toBe('[]');
       const html = result.compilation.assets['index.html'].source();
-      expect(html).toContain('<link rel="preload" href="/home.js');
-      expect(html).toContain('<link rel="preload" href="/home.js.map');
-      expect(html).not.toContain('<link rel="preload" href="/bundle.js"');
+      expect(html).toContain('<link rel="preload" as="script" href="/home.js');
+      expect(html).toContain('<link rel="preload" as="script" href="/home.js.map');
+      expect(html).not.toContain('<link rel="preload" as="script" href="/bundle.js"');
       done();
     });
     compiler.outputFileSystem = new MemoryFileSystem();
@@ -243,7 +300,7 @@ describe('filtering unwanted files', function() {
       expect(err).toBeFalsy();
       expect(JSON.stringify(result.compilation.errors)).toBe('[]');
       const html = result.compilation.assets['index.html'].source();
-      expect(html).toContain('<link rel="preload" href="/chunk.');
+      expect(html).toContain('<link rel="preload" as="script" href="/chunk.');
       expect(html).not.toContain('.map"');
       done();
     });


### PR DESCRIPTION
This PR is for #18 
if `as` is not specified in plugin config, the plugin will use suffix of file name to determine whether `as=style` or `as=script` should be used.